### PR TITLE
Fix HMRC new links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ published for agricultural levy purposes or the bit error rate (BER) daily rate 
 
 ## 🛠 CSV and XML converter
 
-HMRC publishes new monthly exchange rates in [CSV][hmrc-csv-rates] and [XML][hmrc-xml-rates] format on its website during
+HMRC publishes new monthly exchange rates in [CSV][hmrc-url] and [XML][hmrc-url] format on its website during
 the last week of the month. The CSV version is usually a few days before the XML one available.
 
 Unfortunately only the XML version can be retrieved programmatically as the URI to CSV contains a unique file descriptor
@@ -77,12 +77,10 @@ which obviously can not be predicted. Therefore the XML converter is being used 
 However, you can always manually add new rates to this repository using [this CSV converter](./script/converter/from_csv.sh).
 
 ```sh
-$ curl --silent https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/874383/exrates-monthly-0420.csv | \
+$ curl --silent https://www.trade-tariff.service.gov.uk/api/v2/exchange_rates/files/monthly_csv_2023-11.csv | \
     ./script/converter/from_csv.sh \
-    > rate/2020/04.json
+    > rate/2023/11.json
 ```
 
 <!-- MARKDOWN LINKS -->
-[hmrc-url]: https://www.gov.uk/government/organisations/hm-revenue-customs
-[hmrc-csv-rates]: https://www.gov.uk/government/publications/hmrc-exchange-rates-for-2020-monthly
-[hmrc-xml-rates]: http://www.hmrc.gov.uk/softwaredevelopers/2020-exrates.html
+[hmrc-url]: https://www.trade-tariff.service.gov.uk/exchange_rates

--- a/script/README_TEMPLATE.md
+++ b/script/README_TEMPLATE.md
@@ -68,7 +68,7 @@ published for agricultural levy purposes or the bit error rate (BER) daily rate 
 
 ## 🛠 CSV and XML converter
 
-HMRC publishes new monthly exchange rates in [CSV][hmrc-csv-rates] and [XML][hmrc-xml-rates] format on its website during
+HMRC publishes new monthly exchange rates in [CSV][hmrc-url] and [XML][hmrc-url] format on its website during
 the last week of the month. The CSV version is usually a few days before the XML one available.
 
 Unfortunately only the XML version can be retrieved programmatically as the URI to CSV contains a unique file descriptor
@@ -77,12 +77,10 @@ which obviously can not be predicted. Therefore the XML converter is being used 
 However, you can always manually add new rates to this repository using [this CSV converter](./script/converter/from_csv.sh).
 
 ```sh
-$ curl --silent https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/874383/exrates-monthly-0420.csv | \
+$ curl --silent https://www.trade-tariff.service.gov.uk/api/v2/exchange_rates/files/monthly_csv_2023-11.csv | \
     ./script/converter/from_csv.sh \
-    > rate/2020/04.json
+    > rate/2023/11.json
 ```
 
 <!-- MARKDOWN LINKS -->
-[hmrc-url]: https://www.gov.uk/government/organisations/hm-revenue-customs
-[hmrc-csv-rates]: https://www.gov.uk/government/publications/hmrc-exchange-rates-for-2020-monthly
-[hmrc-xml-rates]: http://www.hmrc.gov.uk/softwaredevelopers/2020-exrates.html
+[hmrc-url]: https://www.trade-tariff.service.gov.uk/exchange_rates

--- a/script/update.sh
+++ b/script/update.sh
@@ -39,8 +39,8 @@ readonly NEXT_YYYY=$(date -d "${LATEST_START_DATE} +1 month" "+%Y")
 readonly NEXT_MM=$(date -d "${LATEST_START_DATE} +1 month" "+%m")
 
 # HMRC breaks its URL scheme sometimes 🤷‍, so we're trying different URLS
-readonly HMRC_URL_01="http://www.hmrc.gov.uk/softwaredevelopers/rates/exrates-monthly-${NEXT_MM}${NEXT_YYYY: -2}.xml"
-readonly HMRC_URL_02="http://www.hmrc.gov.uk/softwaredevelopers/rates/exrates-monthly-${NEXT_MM}${NEXT_YYYY: -2}.XML"
+readonly HMRC_URL_01="https://www.trade-tariff.service.gov.uk/api/v2/exchange_rates/files/monthly_xml_${NEXT_YYYY}-${NEXT_MM}.xml"
+readonly HMRC_URL_02="https://www.trade-tariff.service.gov.uk/api/v2/exchange_rates/files/monthly_xml_${NEXT_YYYY}-${NEXT_MM}.XML"
 HMRC_URL="${HMRC_URL_01}"
 
 readonly STATUS_CODE_01=$(curl --silent -LI -X OPTIONS "${HMRC_URL_01}" -o /dev/null -w '%{http_code}')


### PR DESCRIPTION
October 2023 URL structure has changed and the API was failing to get the new rates.